### PR TITLE
Replace generic Docsy example content with Tri-Cities Mesh site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,187 +1,93 @@
-# Docsy Example
+# Tri-Cities Mesh
 
-[Docsy][] is a [Hugo theme module][] for technical documentation sites, providing easy
-site navigation, structure, and more. This **Docsy Example Project** uses the Docsy
-theme component as a hugo module and provides a skeleton documentation structure for you to use.
-You can clone/copy this project and edit it with your own content, or use it as an example.
+The source for **[tricitiesmesh.net](https://tricitiesmesh.net)** — a community site for [Meshtastic](https://meshtastic.org) users in the Tri-Cities area of Northeast Tennessee (Kingsport · Johnson City · Bristol).
 
-In this project, the Docsy theme is pulled in as a Hugo module, together with
-its dependencies:
+Meshtastic is an open-source, off-grid, long-range messaging network built on affordable LoRa radios. No cell service, no fees, no internet required.
 
-```console
-$ hugo mod graph
-...
-```
+---
 
-For Docsy documentation, see [Docsy user guide][].
+## About the Site
 
-This Docsy Example Project is hosted on [Netlify][] at [example.docsy.dev][].
-You can view deploy logs from the [deploy section of the project's Netlify
-dashboard][deploys], or this [alternate dashboard][].
+This site is built with [Hugo](https://gohugo.io/) using the [Docsy](https://www.docsy.dev/) theme. It covers:
 
-This is not an officially supported Google product. This project is currently maintained.
+- **Getting started** guides for new users
+- **Node directory** — community nodes across the region
+- **Coverage map** links
+- **Blog** and community news
 
-## Using the Docsy Example Project as a template
+Live site: [tricitiesmesh.net](https://tricitiesmesh.net)
 
-A simple way to get started is to use this project as a template, which gives you a site project that is set up and ready to use. To do this:
+---
 
-1. Use the dropdown for switching branches/tags to change to the **latest** released tag.
+## Running Locally
 
-2. Click **Use this template**.
+### Prerequisites
 
-3. Select a name for your new project and click **Create repository from template**.
+- [Hugo **extended**](https://gohugo.io/installation/) v0.146.0 or later
+- [Go](https://go.dev/dl/) 1.18 or later
+- [Node.js](https://nodejs.org/) (for PostCSS/SCSS)
 
-4. Make your own local working copy of your new repo using git clone, replacing https://github.com/me/example.git with your repo’s web URL:
+### Setup
 
 ```bash
-git clone --depth 1 https://github.com/me/example.git
-```
-
-Depending on your environment you may need to adjust the top-level `module` settings in your project's Hugo config file, for example, by adding a proxy to use when downloading remote modules.
-You can find details of what these configuration settings do in the [Hugo modules documentation](https://gohugo.io/hugo-modules/configuration/#module-config-top-level). 
-
-Once your settings are adjusted, you can edit your own versions of the site’s source files.
-
-If you want to do SCSS edits and want to publish these, you need to install `PostCSS`
-
-```bash
+git clone https://github.com/joshuacarmack/tricitiesmesh.net.git
+cd tricitiesmesh.net
 npm install
-```
-
-## Running the website locally
-
-Building and running the site locally requires a recent `extended` version of [Hugo](https://gohugo.io).
-You can find out more about how to install Hugo for your environment in our
-[Getting started](https://www.docsy.dev/docs/getting-started/#prerequisites-and-installation) guide.
-
-Once you've made your working copy of the site repo, from the repo root folder, run:
-
-```bash
 hugo server
 ```
 
-## Running a container locally
+Open [http://localhost:1313](http://localhost:1313) in your browser. Changes hot-reload automatically.
 
-You can run docsy-example inside a [Docker](https://docs.docker.com/)
-container, the container runs with a volume bound to the `docsy-example`
-folder. This approach doesn't require you to install any dependencies other
-than [Docker Desktop](https://www.docker.com/products/docker-desktop) on
-Windows and Mac, and [Docker Compose](https://docs.docker.com/compose/install/)
-on Linux.
+### Running with Docker
 
-1. Build the docker image
+If you'd rather skip installing dependencies:
 
-   ```bash
-   docker-compose build
-   ```
+```bash
+docker-compose up --build
+```
 
-1. Run the built image
+Then open [http://localhost:1313](http://localhost:1313). Press **Ctrl+C** to stop.
 
-   ```bash
-   docker-compose up
-   ```
-
-   > NOTE: You can run both commands at once with `docker-compose up --build`.
-
-1. Verify that the service is working.
-
-   Open your web browser and type `http://localhost:1313` in your navigation bar,
-   This opens a local instance of the docsy-example homepage. You can now make
-   changes to the docsy example and those changes will immediately show up in your
-   browser after you save.
-
-### Cleanup
-
-To stop Docker Compose, on your terminal window, press **Ctrl + C**.
-
-To remove the produced images run:
+To clean up:
 
 ```bash
 docker-compose rm
 ```
-For more information see the [Docker Compose documentation][].
 
-## Using a local Docsy clone
+---
 
-Make sure your installed go version is `1.18` or higher.
+## Contributing
 
-Clone the latest version of the docsy theme into the parent folder of your project. The newly created repo should now reside in a sibling folder of your site's root folder.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full details. The short version:
 
-```shell
-cd root-of-your-site
-git clone --branch v0.12.0 https://github.com/google/docsy.git ../docsy
-```
+1. Fork the repo and create a feature branch.
+2. Make your changes.
+3. Open a pull request — all submissions go through GitHub PR review.
 
-Now run:
+Content lives in `content/en/`. Hugo's [content organization docs](https://gohugo.io/content-management/organization/) are a good reference if you're adding pages.
 
-```shell
-HUGO_MODULE_WORKSPACE=docsy.work hugo server --ignoreVendorPaths "**"
-```
-
-or, when using npm, prepend `local` to the script you want to invoke, e.g.:
-
-```shell
-npm run local serve
-```
-
-By using the `HUGO_MODULE_WORKSPACE` directive (either directly or via prefix `local` when using npm), the server now watches all files and directories inside the sibling directory `../docsy` , too. Any changes inside the local `docsy` theme clone are  now immediately picked up (hot reload), you can instantly see the effect of your local edits.
-
-In the command above, we used the environment variable `HUGO_MODULE_WORKSPACE` to tell hugo about the local workspace file `docsy.work`. Alternatively, you can declare the workspace file inside your settings file `hugo.toml`:
-
-```toml
-[module]
-  workspace = "docsy.work"
-```
-
-Your project's `hugo.toml` file already contains these lines, the directive for workspace assignment is commented out, however. Remove the two trailing comment characters '//' so that this line takes effect.
+---
 
 ## Troubleshooting
 
-As you run the website locally, you may run into the following error:
+**`shortcode "blocks/cover" not found`** — You're running an outdated Hugo version. Upgrade to v0.146.0+.
 
-```console
-$ hugo server
-WARN 2023/06/27 16:59:06 Module "project" is not compatible with this Hugo version; run "hugo mod graph" for more information.
-Start building sites …
-hugo v0.101.0-466fa43c16709b4483689930a4f9ac8add5c9f66+extended windows/amd64 BuildDate=2022-06-16T07:09:16Z VendorInfo=gohugoio
-Error: Error building site: "C:\Users\foo\path\to\docsy-example\content\en\_index.md:5:1": failed to extract shortcode: template for shortcode "blocks/cover" not found
-Built in 27 ms
-```
+**`TOCSS: failed to transform "scss/main.scss"`** — You need the Hugo **extended** edition, not the standard one.
 
-This error occurs if you are running an outdated version of Hugo. As of docsy theme version `v0.12.0`, hugo version `0.146.0` or higher is required.
-See this [section](https://www.docsy.dev/docs/get-started/docsy-as-module/installation-prerequisites/#install-hugo) of the user guide for instructions on how to install Hugo.
+**`binary with name "go" not found`** — Go is not installed. [Install Go](https://go.dev/dl/) and try again.
 
-Or you may be confronted with the following error:
+---
 
-```console
-$ hugo server
+## Community
 
-INFO 2021/01/21 21:07:55 Using config file:
-Building sites … INFO 2021/01/21 21:07:55 syncing static files to /
-Built in 288 ms
-Error: Error building site: TOCSS: failed to transform "scss/main.scss" (text/x-scss): resource "scss/scss/main.scss_9fadf33d895a46083cdd64396b57ef68" not found in file cache
-```
+| Channel | Link |
+|---|---|
+| Facebook Group | [Tri-Cities Meshtastic](https://www.facebook.com/groups/1096862151623739) |
+| Discord | [discord.gg/ZC9wqtxWTV](https://discord.gg/ZC9wqtxWTV) |
+| Live Coverage Map | [meshtastic.n4jhc.com](https://meshtastic.n4jhc.com/) |
 
-This error occurs if you have not installed the extended version of Hugo.
-See this [section](https://www.docsy.dev/docs/get-started/docsy-as-module/installation-prerequisites/#install-hugo) of the user guide for instructions on how to install Hugo.
+---
 
-Or you may encounter the following error:
+## License
 
-```console
-$ hugo server
-
-Error: failed to download modules: binary with name "go" not found
-```
-
-This error occurs if the `go` programming language is not available on your system.
-See this [section](https://www.docsy.dev/docs/get-started/docsy-as-module/installation-prerequisites/#install-go-language) of the user guide for instructions on how to install `go`.
-
-
-[alternate dashboard]: https://app.netlify.com/sites/goldydocs/deploys
-[deploys]: https://app.netlify.com/sites/docsy-example/deploys
-[Docsy user guide]: https://docsy.dev/docs
-[Docsy]: https://github.com/google/docsy
-[example.docsy.dev]: https://example.docsy.dev
-[Hugo theme module]: https://gohugo.io/hugo-modules/use-modules/#use-a-module-for-a-theme
-[Netlify]: https://netlify.com
-[Docker Compose documentation]: https://docs.docker.com/compose/gettingstarted/
+See [LICENSE](LICENSE). This site is not affiliated with or endorsed by the Meshtastic project.


### PR DESCRIPTION
## Summary
Completely rewrote the README.md to reflect the actual purpose and content of this repository as the Tri-Cities Mesh community website, replacing the generic Docsy example documentation.

## Changes Made
- **Replaced project identity**: Changed from "Docsy Example" to "Tri-Cities Mesh" with clear description of the site's purpose
- **Updated project description**: Added context about Meshtastic and the Tri-Cities area (Kingsport, Johnson City, Bristol in Northeast Tennessee)
- **Simplified setup instructions**: 
  - Consolidated prerequisites into a clear list (Hugo extended, Go, Node.js)
  - Streamlined local development setup with direct clone and run commands
  - Kept Docker option but simplified the instructions
- **Added community resources**: New section with links to Facebook Group, Discord, and live coverage map
- **Added contributing guidelines**: Reference to CONTRIBUTING.md with basic contribution workflow
- **Improved troubleshooting**: Focused on actual issues users may encounter (Hugo version, extended edition requirement, Go installation)
- **Added license section**: Clarified licensing and non-affiliation with Meshtastic project
- **Removed Docsy-specific content**: Eliminated references to Docsy theme modules, Hugo module workspaces, and generic template instructions

## Notable Details
The new README is significantly more concise (93 lines vs 187) while being more relevant and actionable for contributors to this specific community project. All generic Docsy example content has been replaced with Tri-Cities Mesh-specific information.

https://claude.ai/code/session_01KTQm4MEa6dfLf1nWa96peq